### PR TITLE
CRAN release v0.2.5

### DIFF
--- a/tools/rpkg/.Rbuildignore
+++ b/tools/rpkg/.Rbuildignore
@@ -12,3 +12,5 @@ configure
 ^docs$
 build-*
 deploy-*
+^cran-comments\.md$
+^CRAN-RELEASE$

--- a/tools/rpkg/.gitignore
+++ b/tools/rpkg/.gitignore
@@ -102,3 +102,4 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 # End of https://www.toptal.com/developers/gitignore/api/windows
+CRAN-RELEASE

--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 0.2.5
+Version: 0.2.5.9000
 Authors@R: 
     c(person(given = "Hannes",
              family = "Mühleisen",

--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 0.2.5.9001
+Version: 0.2.5.9002
 Authors@R: 
     c(person(given = "Hannes",
              family = "Mühleisen",

--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 0.2.5.9002
+Version: 0.2.5.9003
 Authors@R: 
     c(person(given = "Hannes",
              family = "Mühleisen",

--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 0.2.5.9003
+Version: 0.2.6
 Authors@R: 
     c(person(given = "Hannes",
              family = "Mühleisen",

--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 0.2.5.9000
+Version: 0.2.5.9001
 Authors@R: 
     c(person(given = "Hannes",
              family = "Mühleisen",

--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 0.2.6
+Version: 0.2.6.9000
 Authors@R: 
     c(person(given = "Hannes",
              family = "Mühleisen",

--- a/tools/rpkg/NEWS.md
+++ b/tools/rpkg/NEWS.md
@@ -1,3 +1,8 @@
+# duckdb 0.2.5.9002 (2020-08-27)
+
+- Internal changes only.
+
+
 # duckdb 0.2.5.9001 (2020-08-27)
 
 - Internal changes only.

--- a/tools/rpkg/NEWS.md
+++ b/tools/rpkg/NEWS.md
@@ -1,3 +1,8 @@
+# duckdb 0.2.5.9003 (2020-08-27)
+
+- Same as previous version.
+
+
 # duckdb 0.2.5.9002 (2020-08-27)
 
 - Internal changes only.

--- a/tools/rpkg/NEWS.md
+++ b/tools/rpkg/NEWS.md
@@ -1,3 +1,8 @@
+# duckdb 0.2.5.9000 (2020-08-27)
+
+- Internal changes only.
+
+
 # duckdb 0.2.5 (2020-08-25)
 
 - Internal changes only.

--- a/tools/rpkg/NEWS.md
+++ b/tools/rpkg/NEWS.md
@@ -1,3 +1,8 @@
+# duckdb 0.2.5.9001 (2020-08-27)
+
+- Internal changes only.
+
+
 # duckdb 0.2.5.9000 (2020-08-27)
 
 - Internal changes only.

--- a/tools/rpkg/NEWS.md
+++ b/tools/rpkg/NEWS.md
@@ -1,3 +1,8 @@
+# duckdb 0.2.6 (2020-09-05)
+
+- Same as previous version.
+
+
 # duckdb 0.2.5.9003 (2020-08-27)
 
 - Same as previous version.

--- a/tools/rpkg/NEWS.md
+++ b/tools/rpkg/NEWS.md
@@ -1,3 +1,8 @@
+# duckdb 0.2.6.9000 (2020-09-05)
+
+- Internal changes only.
+
+
 # duckdb 0.2.6 (2020-09-05)
 
 - Same as previous version.

--- a/tools/rpkg/cran-comments.md
+++ b/tools/rpkg/cran-comments.md
@@ -7,10 +7,10 @@ duckdb 0.2.5
 ## R CMD check results
 
 - [x] Checked locally, R 4.0.2
-- [ ] Checked on CI system, R 4.0.2
-- [ ] Checked on win-builder, R devel
+- [x] Checked on CI system, R 4.0.2
+- [x] Checked on win-builder, R devel
 
-- [ ] Check the boxes above after successful execution and remove this line. Then run `fledge::release()`.
+- [x] Check the boxes above after successful execution and remove this line. Then run `fledge::release()`.
 
 ## Current CRAN check results
 

--- a/tools/rpkg/cran-comments.md
+++ b/tools/rpkg/cran-comments.md
@@ -1,0 +1,17 @@
+duckdb 0.2.5
+
+## Cran Repository Policy
+
+- [x] Reviewed CRP last edited 2020-07-11.
+
+## R CMD check results
+
+- [x] Checked locally, R 4.0.2
+- [ ] Checked on CI system, R 4.0.2
+- [ ] Checked on win-builder, R devel
+
+- [ ] Check the boxes above after successful execution and remove this line. Then run `fledge::release()`.
+
+## Current CRAN check results
+
+Initial release.


### PR DESCRIPTION
duckdb 0.2.5

## Cran Repository Policy

- [x] Reviewed CRP last edited 2020-07-11.

## R CMD check results

- [x] Checked locally, R 4.0.2
- [ ] Checked on CI system, R 4.0.2
- [ ] Checked on win-builder, R devel

- [ ] Check the boxes above after successful execution and remove this line. Then run `fledge::release()`.

## Current CRAN check results

Initial release.
